### PR TITLE
feat: add support for i18n t calls with more than parameter

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_i18n/listeners/completion.rb
+++ b/lib/ruby_lsp/ruby_lsp_i18n/listeners/completion.rb
@@ -36,7 +36,7 @@ module RubyLsp
 
         arguments = node.arguments
         return unless arguments
-        return unless arguments.arguments.size == 1
+        return if arguments.arguments.empty?
 
         key_node = arguments.arguments.first
         return unless key_node.is_a?(Prism::StringNode)

--- a/lib/ruby_lsp/ruby_lsp_i18n/listeners/inlay_hints.rb
+++ b/lib/ruby_lsp/ruby_lsp_i18n/listeners/inlay_hints.rb
@@ -39,7 +39,7 @@ module RubyLsp
 
         arguments = node.arguments
         return unless arguments
-        return unless arguments.arguments.size == 1
+        return if arguments.arguments.empty?
 
         key_node = arguments.arguments.first
         return unless key_node.is_a?(Prism::StringNode)


### PR DESCRIPTION
Add support to calls to I18n with static string key and more than one parameter. For example

```ruby
I18n.t("key", name: "bob")
```
now also autocompletes given the full key.

This is only for I18n values interoplation on the translations and does not work on scopes or different locales.