### PR TITLE
Allow specifying language other than ES

### DIFF
--- a/lib/ruby_lsp/ruby_lsp_i18n/i18n_index.rb
+++ b/lib/ruby_lsp/ruby_lsp_i18n/i18n_index.rb
@@ -26,6 +26,9 @@ module RubyLsp
     class I18nIndex
       extend T::Sig
 
+      sig { returns(String) }
+      attr_reader :language
+
       sig { params(language: String).void }
       def initialize(language:)
         @language = language

--- a/lib/ruby_lsp/ruby_lsp_i18n/listeners/inlay_hints.rb
+++ b/lib/ruby_lsp/ruby_lsp_i18n/listeners/inlay_hints.rb
@@ -51,11 +51,13 @@ module RubyLsp
         matches = @i18n_index.find(key)
 
         tooltip_content = <<~MARKDOWN
-          **Translations (es)**
+          **Translations (#{@i18n_index.language})**
           #{matches.map { |match| "- [#{match.file}](#{create_file_uri(match.file)}): #{match.value}" }.join("\n")}
         MARKDOWN
 
-        suggested_path = @path.to_s.gsub("app", "config/locales").gsub(@path.basename.to_s, "es.yml")
+        suggested_path = @path.to_s
+          .gsub("app", "config/locales")
+          .gsub(@path.basename.to_s, "#{@i18n_index.language}.yml")
         suggested_path_link = create_file_uri(suggested_path)
         if matches.empty?
           tooltip_content += <<~MARKDOWN


### PR DESCRIPTION
 Currently, the extension works only with `es.yml` translation files. Adding an option to customise the language

Example config:
```json
{
  "rubyLsp.addonSettings": {
    "Ruby LSP I18n": {
      "language": "en-dev"
    }
  },
}
```